### PR TITLE
Feature and stability updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,15 @@ SCENARIO_P("User updates their email address", UniqueFixtureName, emails) {
 }
 ```
 
+### Typed SCENARIO
+
+Typed scenarios require a fixture and can be achieved with
+
+```cpp
+SCENARIO_T("This is my scenario description", MyUniqueFixture, Types()) {
+}
+```
+
 ### DISABLED tests
 
 To disable a `SCENARIO`, just prefix the scenario string with `"DISABLED_"` as you would for a regular TEST

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ SCENARIO_P_VERBOSE(ExplicitTestName, "This is my scenario description", MyFixtur
 }
 ```
 
-Both of these macros deal with `INSTANTIATE_TEST_CASE_P` so that it is not required in your tests.
+Both of these macros deal with `INSTANTIATE_TEST_SUITE_P` so that it is not required in your tests.
 The difference between them is just what appears in the test output. `SCENARIO_P` will by default prefix test output with
 `TEST_P` and presumes the fixture name and description are sufficient enough to give meaningful test output.
 Where this is not the case, you can substitute additional test information for the `ExplicitTestName` placeholder.

--- a/include/cppbdd/gtestbdd.h
+++ b/include/cppbdd/gtestbdd.h
@@ -34,7 +34,7 @@ namespace gtestbdd
 
         virtual ~Scenario()
         {
-            if (!mGiven && !mWhen && !mThen)
+            if(!mGiven && !mWhen && !mThen)
             {
                 return;
             }
@@ -60,13 +60,23 @@ namespace gtestbdd
 
         void given(const std::string &description)
         {
+            if (mGiven)
+            {
+                printError("GIVEN clause is duplicated. AND should be used for additional statements.");
+                assert(false);
+            }
             mGiven = true;
             printGiven(description);
         }
 
         void then(ExpectString description)
         {
-            if(mGiven)
+            if(!mThenExpects.empty())
+            {
+                printError("THEN(EXPECT()) clause is duplicated. AND should be used for additional statements.");
+                assert(false);
+            }
+            else if(mGiven)
             {
                 mThenExpects.push_back(std::move(description).GetString());
             }
@@ -79,7 +89,12 @@ namespace gtestbdd
 
         void when(const std::string &description)
         {
-            if(mGiven)
+            if(mWhen)
+            {
+                printError("WHEN clause is duplicated. AND should be used for additional statements.");
+                assert(false);
+            }
+            else if(mGiven)
             {
                 mWhen = true;
                 printWhen(description);
@@ -93,7 +108,12 @@ namespace gtestbdd
 
         void then(const std::string &description)
         {
-            if(mWhen)
+            if(mThen)
+            {
+                printError("THEN clause is duplicated. AND should be used for additional statements.");
+                assert(false);
+            }
+            else if(mWhen)
             {
                 mThen = true;
 

--- a/include/cppbdd/gtestbdd.h
+++ b/include/cppbdd/gtestbdd.h
@@ -230,10 +230,14 @@ namespace gtestbdd
         static int AddToRegistry() {\
             ::testing::UnitTest::GetInstance()->parameterized_test_registry().\
                 GetTestCasePatternHolder<FixtureClass>(\
-                    #FixtureClass, __FILE__, __LINE__)->AddTestPattern(\
-                        #FixtureClass,\
-                        Description,\
-                        new ::testing::internal::TestMetaFactory<TestClass>());\
+                    GTEST_STRINGIFY_(FixtureClass),\
+                    ::testing::internal::CodeLocation(\
+                        __FILE__, __LINE__))->AddTestPattern(\
+                            GTEST_STRINGIFY_(FixtureClass),\
+                            Description,\
+                            new ::testing::internal::TestMetaFactory<TestClass>(),\
+                            ::testing::internal::CodeLocation(\
+                                __FILE__, __LINE__));\
             return 0;\
         }\
         static int gtest_registering_dummy_;\

--- a/include/cppbdd/gtestbdd.h
+++ b/include/cppbdd/gtestbdd.h
@@ -197,7 +197,7 @@ namespace gtestbdd
     \
     int TestClass::gtest_registering_dummy_ =\
         TestClass::AddToRegistry();\
-    INSTANTIATE_TEST_CASE_P(TestName, FixtureClass, Values);\
+    INSTANTIATE_TEST_SUITE_P(TestName, FixtureClass, Values);\
     void TestClass::TestBody()
 
 #define SCENARIO_P_VERBOSE(testname, description, fixture, values) \

--- a/include/cppbdd/gtestbdd.h
+++ b/include/cppbdd/gtestbdd.h
@@ -100,7 +100,7 @@ namespace gtestbdd
                 if(!mThenExpects.empty())
                 {
                     printThen(mThenExpects[0]);
-                    for (auto i = 1; i < mThenExpects.size(); ++i)
+                    for (size_t i = 1; i < mThenExpects.size(); ++i)
                         printAnd(mThenExpects[i]);
                     mThenExpects.clear();
                     printAnd(description);

--- a/include/cppbdd/gtestbdd.h
+++ b/include/cppbdd/gtestbdd.h
@@ -154,7 +154,8 @@ namespace gtestbdd
     private:\
         virtual void TestBody();\
         static ::testing::TestInfo* const test_info_ GTEST_ATTRIBUTE_UNUSED_;\
-        GTEST_DISALLOW_COPY_AND_ASSIGN_(TestClass);\
+        TestClass(const TestClass&) = delete;\
+        TestClass& operator=(const TestClass&) = delete;\
     };\
     \
     ::testing::TestInfo* const TestClass\

--- a/include/cppbdd/qtestbdd.h
+++ b/include/cppbdd/qtestbdd.h
@@ -17,7 +17,7 @@ namespace qtestbdd
 
         virtual ~Scenario()
         {
-            if (!mGiven && !mWhen && !mThen)
+            if(!mGiven && !mWhen && !mThen)
             {
                 return;
             }
@@ -40,13 +40,21 @@ namespace qtestbdd
 
         void given(const QString &description)
         {
+            if (mGiven)
+            {
+                QFAIL("GIVEN clause is duplicated. AND should be used for additional statements.");
+            }
             mGiven = true;
             printGiven(description);
         }
 
         void when(const QString &description)
         {
-            if(mGiven)
+            if(mWhen)
+            {
+                QFAIL("WHEN clause is duplicated. AND should be used for additional statements.");
+            }
+            else if(mGiven)
             {
                 mWhen = true;
                 printWhen(description);
@@ -59,7 +67,11 @@ namespace qtestbdd
 
         void then(const QString &description)
         {
-            if(mWhen)
+            if(mThen)
+            {
+                QFAIL("THEN clause is duplicated. AND should be used for additional statements.");
+            }
+            else if(mWhen)
             {
                 mThen = true;
                 printThen(description);


### PR DESCRIPTION
* Added support for gTest v1.12.0 (fixed multiple compilation issues)
* Added typed test support for gTest (SCENARIO_T)
* Added support for gMock expectations by provising the THEN(EXPECT()) clause. This allows writing "then" statements before writing the "when" section while keeping the output fully BDD compatible.
* Added checks against using the same clause multiple times in a scenario.